### PR TITLE
Improve hover reveal tooltip styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,3 @@
-
 .workspace-leaf-content .hover-reveal {
     position: relative;
     text-decoration: underline;
@@ -18,16 +17,31 @@
     bottom: 100%;
     left: 50%;
     transform: translateX(-50%);
-    padding: 5px 10px;
+    padding: 3px 10px;	
+    
     background-color: var(--background-primary);
     border: 1px solid var(--background-modifier-border);
     color: var(--text-normal);
     border-radius: 4px;
     font-size: 0.9em;
-    white-space: nowrap;
+    font-weight: normal;
+	
+    white-space: normal;
+    word-break: normal;
+    overflow-wrap: break-word;
+    display: inline-block;
+    width: max-content;
+    max-width: 400px;
+    box-sizing: content-box;
+    max-height: 150px;
+    overflow-y: hidden;
     z-index: 1000;
     opacity: 0;
-    transition: opacity 0.2s ease-in-out, visibility 0.2s ease-in-out;
+    transition: opacity 0.2s ease-in-out, visibility 0.2s ease-in-out, padding 0.2s ease-in-out;
+}
+
+.workspace-leaf-content .hover-reveal-tooltip:hover {
+    overflow-y: auto;
 }
 
 .workspace-leaf-content .hover-reveal:hover .hover-reveal-tooltip {
@@ -62,4 +76,3 @@
     border-radius: 4px;
     cursor: pointer;
 }
-


### PR DESCRIPTION
Padding: Reduced padding from 5px 10px to 3px 10px to make the tooltip more compact.
Font Weight: Changed font-weight from bold to normal to make the tooltip less prominent.
White Space: Changed white-space from nowrap to normal to allow text to wrap more naturally.
Word Break: Set overflow-wrap to break-word to break long words if necessary.
Display: Set display to inline-block to integrate the tooltip better into the content flow.
Width: Set width to max-content to adjust the tooltip width to the content.
Max Width: Set max-width to 400px to define a maximum width for the tooltip.
Box Sizing: Set box-sizing to content-box to correctly calculate the width and height of the tooltip.
Max Height: Set max-height to 150px to define a maximum height for the tooltip.
Overflow Y: Set overflow-y to hidden to hide the scrollbar when the content does not overflow.
Transition: Extended transition to include padding for a smooth padding animation.
Hover State: Added a :hover state to set overflow-y to auto when the tooltip is hovered, displaying a scrollbar if the content overflows.